### PR TITLE
Fix tests by mocking dependencies and increasing timeouts

### DIFF
--- a/__tests__/customer/ProductPage.test.js
+++ b/__tests__/customer/ProductPage.test.js
@@ -1,6 +1,11 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import Product from '@/app/(customer)/products/page';
 import '@testing-library/jest-dom';
+import { useSearchParams } from 'next/navigation';
+
+jest.mock('next/navigation', () => ({
+    useSearchParams: jest.fn(),
+}));
 
 // Mock fetch
 global.fetch = jest.fn((url) => {
@@ -32,7 +37,7 @@ global.fetch = jest.fn((url) => {
         });
     }
     return Promise.reject(new Error('Unknown endpoint'));
-});
+}));
 
 describe('Product', () => {
     beforeEach(() => {
@@ -53,7 +58,7 @@ describe('Product', () => {
         });
 
         expect(asFragment()).toMatchSnapshot();
-    });
+    }, 10000);
 
     it('should handle search functionality', async () => {
         const searchParams = new URLSearchParams();
@@ -61,7 +66,9 @@ describe('Product', () => {
         searchParams.set('products', 'Test Product');
         searchParams.set('all_product', 'All Products');
 
-        render(<Product searchParams={searchParams} />);
+        useSearchParams.mockReturnValue(searchParams);
+
+        render(<Product />);
 
         fireEvent.change(screen.getByPlaceholderText(/Search.../i), { target: { value: 'Test Product 1' } });
         fireEvent.submit(screen.getByRole('button', { name: /Cari/i }));
@@ -70,7 +77,7 @@ describe('Product', () => {
             expect(screen.getByText(/Test Product 1/i)).toBeInTheDocument();
             expect(screen.queryByText(/Test Product 2/i)).not.toBeInTheDocument();
         });
-    });
+    }, 10000);
 
     it('should handle sorting functionality', async () => {
         render(<Product />);
@@ -92,7 +99,7 @@ describe('Product', () => {
             expect(products[0]).toHaveTextContent('Test Product 2');
             expect(products[1]).toHaveTextContent('Test Product 1');
         });
-    });
+    }, 10000);
 
     it('should handle filter functionality', async () => {
         render(<Product />);
@@ -104,7 +111,7 @@ describe('Product', () => {
             expect(screen.getByText(/Test Product 1/i)).toBeInTheDocument();
             expect(screen.queryByText(/Test Product 2/i)).not.toBeInTheDocument();
         });
-    });
+    }, 10000);
 
     it('should handle pagination functionality', async () => {
         render(<Product />);
@@ -115,7 +122,7 @@ describe('Product', () => {
             expect(screen.getByText(/Test Product 1/i)).toBeInTheDocument();
             expect(screen.getByText(/Test Product 2/i)).toBeInTheDocument();
         });
-    });
+    }, 10000);
 
     it('should handle API errors gracefully', async () => {
         fetch.mockImplementationOnce(() => Promise.resolve({
@@ -128,7 +135,7 @@ describe('Product', () => {
         await waitFor(() => {
             expect(screen.getByText(/Failed to fetch products/i)).toBeInTheDocument();
         });
-    });
+    }, 10000);
 
     it('should handle invalid input gracefully', async () => {
         render(<Product />);
@@ -140,7 +147,7 @@ describe('Product', () => {
             expect(screen.getByText(/Test Product 1/i)).toBeInTheDocument();
             expect(screen.getByText(/Test Product 2/i)).toBeInTheDocument();
         });
-    });
+    }, 10000);
 
     it('should handle edge cases gracefully', async () => {
         fetch.mockImplementationOnce(() => Promise.resolve({
@@ -165,5 +172,5 @@ describe('Product', () => {
         });
 
         expect(screen.getByText(/Rp 0/i)).toBeInTheDocument();
-    });
+    }, 10000);
 });

--- a/__tests__/dashboard/CategoryDialog.test.js
+++ b/__tests__/dashboard/CategoryDialog.test.js
@@ -57,7 +57,7 @@ describe('ManageCategoriesDialog', () => {
         });
 
         expect(asFragment()).toMatchSnapshot();
-    });
+    }, 10000);
 
     it('should delete a category', async () => {
         const { asFragment } = render(<ManageCategoriesDialog />);
@@ -81,7 +81,7 @@ describe('ManageCategoriesDialog', () => {
         });
 
         expect(asFragment()).toMatchSnapshot();
-    });
+    }, 10000);
 
     it('should display validation error when adding an empty category', async () => {
         const { asFragment } = render(<ManageCategoriesDialog />);
@@ -99,7 +99,7 @@ describe('ManageCategoriesDialog', () => {
         });
 
         expect(asFragment()).toMatchSnapshot();
-    });
+    }, 10000);
 
     it('should handle API errors gracefully when adding a category', async () => {
         fetch.mockImplementationOnce(() => Promise.resolve({
@@ -123,7 +123,7 @@ describe('ManageCategoriesDialog', () => {
         });
 
         expect(asFragment()).toMatchSnapshot();
-    });
+    }, 10000);
 
     it('should handle API errors gracefully when deleting a category', async () => {
         fetch.mockImplementationOnce(() => Promise.resolve({
@@ -152,7 +152,7 @@ describe('ManageCategoriesDialog', () => {
         });
 
         expect(asFragment()).toMatchSnapshot();
-    });
+    }, 10000);
 
     it('should handle edge cases gracefully', async () => {
         fetch.mockImplementationOnce(() => Promise.resolve({
@@ -173,7 +173,7 @@ describe('ManageCategoriesDialog', () => {
         expect(screen.getByText(/Edge Case Category/i)).toBeInTheDocument();
 
         expect(asFragment()).toMatchSnapshot();
-    });
+    }, 10000);
 
     it('should handle invalid input gracefully', async () => {
         const { asFragment } = render(<ManageCategoriesDialog />);
@@ -192,7 +192,7 @@ describe('ManageCategoriesDialog', () => {
         });
 
         expect(asFragment()).toMatchSnapshot();
-    });
+    }, 10000);
 
     it('should handle non-array responses for categories', async () => {
         fetch.mockImplementationOnce(() => Promise.resolve({
@@ -211,5 +211,5 @@ describe('ManageCategoriesDialog', () => {
         expect(screen.queryByText(/Not an array/i)).not.toBeInTheDocument();
 
         expect(asFragment()).toMatchSnapshot();
-    });
+    }, 10000);
 });

--- a/__tests__/dashboard/CustomersPage.test.js
+++ b/__tests__/dashboard/CustomersPage.test.js
@@ -16,6 +16,19 @@ jest.mock('@/lib/supabase/client_admin', () => ({
     },
 }));
 
+jest.mock('@/components/ui/sidebar', () => ({
+    ...jest.requireActual('@/components/ui/sidebar'),
+    useSidebar: jest.fn(() => ({
+        state: 'expanded',
+        open: true,
+        setOpen: jest.fn(),
+        isMobile: false,
+        openMobile: false,
+        setOpenMobile: jest.fn(),
+        toggleSidebar: jest.fn(),
+    })),
+}));
+
 describe('CustomersPage', () => {
     const mockUsers = [
         {

--- a/__tests__/dashboard/FaqPage.test.js
+++ b/__tests__/dashboard/FaqPage.test.js
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import FaqPage from '@/app/dashboard/faq/page';
 import '@testing-library/jest-dom';
-import { SidebarProvider } from '@/context/SidebarContext';
+import { SidebarProvider, useSidebar } from '@/components/ui/sidebar';
 
 // Mock fetch
 global.fetch = jest.fn((url, options) => {
@@ -36,6 +36,19 @@ window.matchMedia = jest.fn().mockImplementation(query => {
         dispatchEvent: jest.fn(),
     };
 });
+
+jest.mock('@/components/ui/sidebar', () => ({
+    ...jest.requireActual('@/components/ui/sidebar'),
+    useSidebar: jest.fn(() => ({
+        state: 'expanded',
+        open: true,
+        setOpen: jest.fn(),
+        isMobile: false,
+        openMobile: false,
+        setOpenMobile: jest.fn(),
+        toggleSidebar: jest.fn(),
+    })),
+}));
 
 describe('FaqPage', () => {
     beforeEach(() => {

--- a/__tests__/dashboard/OrdersPage.test.js
+++ b/__tests__/dashboard/OrdersPage.test.js
@@ -42,6 +42,19 @@ const usersData = [
     { id: "456", email: "jane.smith@example.com" },
 ];
 
+window.matchMedia = jest.fn().mockImplementation(query => {
+    return {
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+    };
+});
+
 describe('OrdersPage', () => {
     beforeEach(() => {
         fetch.mockClear();

--- a/__tests__/dashboard/ProductsPage.test.js
+++ b/__tests__/dashboard/ProductsPage.test.js
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ProductPage from '@/app/dashboard/products/page';
 import '@testing-library/jest-dom';
 import { supabase } from '@/lib/supabase/client';
+import { useSidebar } from '@/components/ui/sidebar';
 
 jest.mock('@/lib/supabase/client', () => ({
     supabase: {
@@ -11,6 +12,19 @@ jest.mock('@/lib/supabase/client', () => ({
             })),
         },
     },
+}));
+
+jest.mock('@/components/ui/sidebar', () => ({
+    ...jest.requireActual('@/components/ui/sidebar'),
+    useSidebar: jest.fn(() => ({
+        state: 'expanded',
+        open: true,
+        setOpen: jest.fn(),
+        isMobile: false,
+        openMobile: false,
+        setOpenMobile: jest.fn(),
+        toggleSidebar: jest.fn(),
+    })),
 }));
 
 global.fetch = jest.fn((url, options) => {
@@ -70,7 +84,7 @@ describe('ProductPage', () => {
         });
 
         expect(asFragment()).toMatchSnapshot();
-    });
+    }, 10000);
 
     it('should handle product deletion', async () => {
         render(<ProductPage />);
@@ -84,7 +98,7 @@ describe('ProductPage', () => {
         await waitFor(() => {
             expect(screen.queryByText(/Test Product 1/i)).not.toBeInTheDocument();
         });
-    });
+    }, 10000);
 
     it('should handle API errors gracefully', async () => {
         fetch.mockImplementationOnce(() => Promise.resolve({
@@ -97,7 +111,7 @@ describe('ProductPage', () => {
         await waitFor(() => {
             expect(screen.getByText(/Failed to fetch products/i)).toBeInTheDocument();
         });
-    });
+    }, 10000);
 
     it('should display validation errors when form is submitted with empty fields', async () => {
         render(<ProductPage />);
@@ -110,7 +124,7 @@ describe('ProductPage', () => {
             expect(screen.getByText('Harus lebih dari 0')).toBeInTheDocument();
             expect(screen.getByText('Setidaknya ada 1 gambar produk')).toBeInTheDocument();
         });
-    });
+    }, 10000);
 
     it('should handle file removal', async () => {
         const handleChange = jest.fn();
@@ -124,7 +138,7 @@ describe('ProductPage', () => {
         await waitFor(() => {
             expect(handleChange).toHaveBeenCalledWith([]);
         });
-    });
+    }, 10000);
 
     it('should handle file removal from storage', async () => {
         const handleChange = jest.fn();
@@ -138,7 +152,7 @@ describe('ProductPage', () => {
             expect(handleChange).toHaveBeenCalledWith([]);
             expect(supabase.storage.from().remove).toHaveBeenCalledWith(['image.png']);
         });
-    });
+    }, 10000);
 
     it('should handle invalid input gracefully', async () => {
         render(<ProductPage />);
@@ -148,7 +162,7 @@ describe('ProductPage', () => {
         await waitFor(() => {
             expect(screen.getByLabelText(/Stock/i)).toHaveValue(0);
         });
-    });
+    }, 10000);
 
     it('should handle edge cases gracefully', async () => {
         fetch.mockImplementationOnce(() => Promise.resolve({
@@ -173,5 +187,5 @@ describe('ProductPage', () => {
         });
 
         expect(screen.getByText(/Rp 0/i)).toBeInTheDocument();
-    });
+    }, 10000);
 });

--- a/hooks/use-mobile.jsx
+++ b/hooks/use-mobile.jsx
@@ -6,13 +6,15 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+      const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+      const onChange = () => {
+        setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      }
+      mql.addEventListener("change", onChange)
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      return () => mql.removeEventListener("change", onChange);
     }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange);
   }, [])
 
   return !!isMobile


### PR DESCRIPTION
Update test files to mock necessary functions and increase timeouts for long-running tests.

* **ProductPage.test.js**
  - Mock `useSearchParams` to prevent "Cannot read properties of null" error.
  - Increase timeout for long-running tests to 10000ms.

* **CategoryDialog.test.js**
  - Increase timeout for long-running tests to 10000ms.

* **CustomersPage.test.js**
  - Mock `useSidebar` to prevent "useSidebar must be used within a SidebarProvider" error.

* **FaqPage.test.js**
  - Mock `useSidebar` to prevent "useSidebar must be used within a SidebarProvider" error.

* **OrdersPage.test.js**
  - Mock `window.matchMedia` to prevent "window.matchMedia is not a function" error.

* **ProductsPage.test.js**
  - Mock `useSidebar` to prevent "useSidebar must be used within a SidebarProvider" error.
  - Increase timeout for long-running tests to 10000ms.

* **use-mobile.jsx**
  - Add a check to ensure `window.matchMedia` is defined before using it.

